### PR TITLE
shows what this would look like with a JUnit Base Test approach

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,33 @@
     <groupId>org.example</groupId>
     <artifactId>quickstart-java</artifactId>
     <version>1.0-SNAPSHOT</version>
-
-
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-java</artifactId>
+            <version>4.0.0-beta-3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.saucelabs</groupId>
+            <artifactId>sauce_bindings</artifactId>
+            <version>1.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.1</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/src/main/java/com/saucelabs/junit/SauceBaseTest.java
+++ b/src/main/java/com/saucelabs/junit/SauceBaseTest.java
@@ -1,0 +1,45 @@
+package com.saucelabs.junit;
+
+import com.saucelabs.saucebindings.SauceSession;
+import com.saucelabs.saucebindings.options.SauceOptions;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TestName;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+import org.openqa.selenium.WebDriver;
+
+public class SauceBaseTest {
+    protected WebDriver driver;
+    protected SauceSession session;
+
+    @Rule
+    public SauceTestWatcher watcher = new SauceTestWatcher();
+
+    @Rule
+    public TestName testName = new TestName();
+
+    public SauceOptions createSauceOptions() {
+        return new SauceOptions();
+    }
+
+    @Before
+    public void setup() {
+        SauceOptions sauceOptions = createSauceOptions();
+        sauceOptions.sauce().setName(testName.getMethodName());
+        session = new SauceSession(sauceOptions);
+        driver = session.start();
+    }
+
+    public class SauceTestWatcher extends TestWatcher {
+        @Override
+        protected void succeeded(Description description) {
+            session.stop(true);
+        }
+
+        @Override
+        protected void failed(Throwable e, Description description) {
+            session.stop(false);
+        }
+    }
+}

--- a/src/test/java/com/saucelabs/quickstart/AdjustOptionsTest.java
+++ b/src/test/java/com/saucelabs/quickstart/AdjustOptionsTest.java
@@ -1,0 +1,28 @@
+package com.saucelabs.quickstart;
+
+import com.saucelabs.saucebindings.JobVisibility;
+import com.saucelabs.saucebindings.SaucePlatform;
+import com.saucelabs.saucebindings.options.SauceOptions;
+import com.saucelabs.junit.SauceBaseTest;
+import org.junit.Test;
+
+import java.time.Duration;
+
+import static org.junit.Assert.assertEquals;
+
+public class AdjustOptionsTest extends SauceBaseTest {
+
+    public SauceOptions createSauceOptions() {
+        return SauceOptions.firefox()
+                .setMaxDuration(Duration.ofMinutes(30))
+                .setJobVisibility(JobVisibility.TEAM)
+                .setPlatformName(SaucePlatform.MAC_CATALINA)
+                .build();
+    }
+
+    @Test
+    public void useCustomOptions() throws AssertionError {
+        driver.navigate().to("https://www.saucedemo.com");
+        assertEquals(driver.getTitle(), "Swag Labs");
+    }
+}

--- a/src/test/java/com/saucelabs/quickstart/QuickstartTest.java
+++ b/src/test/java/com/saucelabs/quickstart/QuickstartTest.java
@@ -1,0 +1,14 @@
+package com.saucelabs.quickstart;
+
+import com.saucelabs.junit.SauceBaseTest;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class QuickstartTest extends SauceBaseTest {
+    @Test
+    public void useAllDefaults() throws AssertionError {
+        driver.navigate().to("https://www.saucedemo.com");
+        assertEquals(driver.getTitle(), "Swag Labs");
+    }
+}


### PR DESCRIPTION
This is the idea for the Base Test

The goal would be to put the code that is in `src/main` directory into a separate package that can be referenced in the pom file instead of both Sauce Bindings & JUnit.